### PR TITLE
Add the pam_groupnet module.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,10 @@ set_target_properties(pam_newnet PROPERTIES PREFIX "")
 add_library(pam_usernet SHARED pam_usernet.c pam_net_checkgroup.c)
 set_target_properties(pam_usernet PROPERTIES PREFIX "")
 
-install(TARGETS pam_newnet pam_usernet
+add_library(pam_groupnet SHARED pam_groupnet.c pam_net_checkgroup.c)
+set_target_properties(pam_groupnet PROPERTIES PREFIX "")
+
+install(TARGETS pam_newnet pam_usernet pam_groupnet
 		DESTINATION ${CMAKE_INSTALL_PAMDIR})
 
 file(GLOB MAN8_PAGES ${CMAKE_CURRENT_SOURCE_DIR}/*.8)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## LIBPAM-NET: create/join network namespaces at login
 
-**libpam-net** implements two pam modules:
+**libpam-net** implements three pam modules:
 
 - **pam_newnet.so**: users belonging to the *newnet* group get a new
 network namespace at login
@@ -9,6 +9,12 @@ network namespace at login
 network name at login. If a network namespace having the same name as the
 username exists, pam runs the user's shell in that namespace. If such a
 namespace does does not exist, it is created during the login process.
+
+- **pam_groupnet.so** users belonging to any group starting with *groupnet-*
+join the network namespace named after the dash of the group.
+If the specified network namespace exists, pam runs the user shell in that
+namespace. If such a namespace does does not exist, it is created during the
+login process.
 
 ### INSTALL:
 
@@ -39,15 +45,17 @@ Add the rules to the pam configuration files: e.g. */etc/pam.d/sshd* or
 ```
 session   required  pam_newnet.so
 session   required  pam_usernet.so
+session   required  pam_groupnet.so
 ```
 
-Create the groups *newnet* and *usernet* including all the users that
-must be subject to one or the other service:
+Create the groups *newnet*, *usernet* and any (or none) *groupnet-&ast;* 
+including all the users that must be subject to one or the other service:
 
 e.g. in /etc/group:
 ```
 newnet:x:149:renzononet
 usernet:x:150:renzousernet
+groupnet-vpn:x:151:renzogroupnet
 ```
 
 ### Use Cases
@@ -64,6 +72,10 @@ created at login time.
 Using **pam_usernet.so** the system administrator can create network namespaces
 for each user in the *usernet* group. Each namespace must be named after each
 username.
+
+Alternatively, using **pam_groupnet.so** the system administrator can create
+different network namespaces to be shared by multiple users. e.g. for forced VPN
+tunneling without affecting other users.
 
 Users will *land* in their assigned network namespace at login. e.g. the
 sysadmin can create a network namespace for user *renzousernet* as follows:

--- a/pam_groupnet.8
+++ b/pam_groupnet.8
@@ -1,0 +1,74 @@
+.TH PAM_GROUPNET 8 "August 17, 2016" "VirtualSquare Labs"
+.SH "NAME"
+pam_groupnet \- join/create a specific network namespace at login
+.SH "SYNOPSIS"
+\fBpam_groupnet\&.so\fR
+.SH DESCRIPTION
+The pam_groupnet PAM module allow each user in \fIgroupnet\fR group to join a
+specific network namespace.
+
+If the specified network namespace exists, pam runs the user shell in that
+namespace. If such a namespace does does not exist, it is created during the login
+process.
+
+The system administrator can specify the network
+namespace to join by creating groups starting with \fIgroupnet-\fR. The text written
+after the dash will be used as the network namespace name to join or create.
+Users will join the network namespace at login.
+
+If a user is part of multiple groups starting with \fIgroupnet-\fR, the first one
+that matches is used. Group testing order is as returned by \fIgetgrouplist(3)\fR.
+
+.SH "OPTIONS"
+.PP
+\fBgroup=\fR\fB\fIgroupname\fR\fR
+.RS 4
+the module operates on users in the group \fIgroupname-\fR instead of \fIgroupnet-\fR.
+.RE
+.PP
+\fBlodown\fR
+.RS 4
+leave the localhost \fIlo\fR interface in the state DOWN.
+.RE
+.PP
+\fBrootshared\fR
+.RS 4
+Leave the root filesystem \fI/\fR as shared so mounts can propagate out to the
+parent namespace. Warning: this feature can create security vulnerabilities if not
+properly used.
+.RE
+
+.SH "RETURN VALUES"
+.PP
+PAM_IGNORE
+.RS 4
+User does not belong to any \fIgroupnet-*\fR group\&.
+.RE
+.PP
+PAM_ABORT
+.RS 4
+Error in retrieving the user id or in the namespace creation/joining\&.
+.RE
+.PP
+PAM_SUCCESS
+.RS 4
+Success\&.
+.RE
+.SH "EXAMPLES"
+.PP
+Add the following line to
+/etc/pam\&.d/sshd
+or /etc/pam\&.d/login
+.sp
+.RS 8
+session   required  pam_groupnet.so
+.RE
+.sp
+.SH "SEE ALSO"
+.PP
+\fBpam.conf\fR(5),
+\fBpam.d\fR(5),
+\fBpam\fR(7)
+.SH "AUTHOR"
+.PP
+pam_groupnet was written by Renzo Davoli and Eduard Caizer, University of Bologna

--- a/pam_groupnet.c
+++ b/pam_groupnet.c
@@ -1,0 +1,384 @@
+/*
+ * pam_groupnet.
+ * Copyright (C) 2017-2019  Renzo Davoli University of Bologna
+ * Copyright (C) 2018-2019  Daniel Gröber
+ * Copyright (C) 2016  Renzo Davoli, Eduard Caizer University of Bologna
+ * Copyright (C) 2011-2017 The iproute2 Authors
+ *
+ * pam_groupnet module
+ *    join users to a specific new or existing network, specified after the dash on the group name.
+ *   (for users belonging to the "groupnet-*" group)
+ *
+ * Cado is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <syslog.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <limits.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/mount.h>
+#include <sys/statvfs.h>
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+
+#include <pam_net_checkgroup.h>
+#include <nlinline.h>
+
+#define DEFAULT_GROUP "groupnet"
+#define NETNS_RUN_DIR "/var/run/netns/"
+#define NETNS_ETC_DIR "/etc/netns"
+
+/**
+ * module args:
+ * lodown, rootshared, group=....
+ */
+struct pam_net_args {
+	const char *group;
+	int flags;
+};
+#define LODOWN 0x1
+#define ROOTSHARED 0x2
+
+/**
+ * parse_argv: parse module arguments
+ */
+static void parse_argv(struct pam_net_args *args, int argc, const char **argv) {
+	for(; argc-- > 0; argv++) {
+		if (strcmp(*argv, "lodown") == 0)
+			args->flags |= LODOWN;
+		else if (strcmp(*argv, "rootshared") == 0)
+			args->flags |= ROOTSHARED;
+		else if (strncmp(*argv, "group=", 6) == 0)
+			args->group = (*argv) + 6;
+		else
+			syslog (LOG_ERR, "Unknown option: %s", *argv);
+	}
+}
+
+/**
+ * init_log: log initialization with the given name
+ */
+void init_log(const char * log_name)
+{
+	setlogmask (LOG_UPTO (LOG_NOTICE));
+	openlog (log_name, LOG_CONS | LOG_PID | LOG_NDELAY, LOG_LOCAL1);
+}
+
+/**
+ * end_log: closes the log previously initialized
+ */
+void end_log()
+{
+	closelog ();
+}
+
+/**
+ * bind_etc: Mount config files from /etc/netns/<name>/ into current namespace.
+ */
+int bind_etc(const char *name, int flags)
+{
+	int rv = 0;
+	char etc_netns_path[sizeof(NETNS_ETC_DIR) + NAME_MAX];
+	char netns_name[PATH_MAX];
+	char etc_name[PATH_MAX];
+	struct dirent *entry;
+	DIR *dir;
+
+	if (flags & ROOTSHARED) {
+		/* ROOTSHARED */
+
+		/* Make /etc a mount point, so we can apply a propagation policy to it
+		 * below */
+		rv = mount("/etc", "/etc", "none", MS_BIND, NULL);
+		if (rv == -1) {
+			syslog (LOG_ERR, "mount --bind %s %s: %s",
+					etc_netns_path, etc_netns_path, strerror(errno));
+			return -1;
+		}
+
+		/* Don't let bind mounts from /etc/netns/<name>/<file> -> /etc/<file>
+		 * propagate back to the parent namespace */
+		if (mount("", "/etc", "none", MS_PRIVATE, NULL)) {
+			syslog (LOG_ERR, "\"mount --make-private /%s\" failed: %s\n",
+					etc_netns_path, strerror(errno));
+			return -1;
+		}
+	}
+
+	snprintf(etc_netns_path, sizeof(etc_netns_path), "%s/%s", NETNS_ETC_DIR, name);
+	dir = opendir(etc_netns_path);
+	if (!dir)
+		return errno == ENOENT ? 0 : -1;
+
+	while ((entry = readdir(dir)) != NULL) {
+		if (strcmp(entry->d_name, ".") == 0)
+			continue;
+		if (strcmp(entry->d_name, "..") == 0)
+			continue;
+
+		snprintf(netns_name, sizeof(netns_name), "%s/%s", etc_netns_path, entry->d_name);
+		snprintf(etc_name, sizeof(etc_name), "/etc/%s", entry->d_name);
+		if (mount(netns_name, etc_name, "none", MS_BIND, NULL) < 0) {
+			syslog (LOG_ERR, "Bind %s -> %s failed: %s",
+					netns_name, etc_name, strerror(errno));
+		}
+	}
+
+	closedir(dir);
+	return 0;
+}
+
+/**
+ * remount_sys: Mount a version of /sys that describes the new network namespace
+ */
+int remount_sys(const char *name, int flags)
+{
+	unsigned long mountflags = MS_NOSUID | MS_NOEXEC | MS_NODEV;
+
+	if ((flags & ROOTSHARED) == 0) {
+		/* DEFAULT behavior: NOT ROOTSHARED */
+		/* Don't let any mounts propagate back to the parent */
+		if (mount("", "/", "none", MS_SLAVE | MS_REC, NULL)) {
+			fprintf(stderr, "\"mount --make-rslave /\" failed: %s\n",
+					strerror(errno));
+			return -1;
+		}
+	} else {
+		/* ROOTSHARED */
+		/* Make /sys private so the remounting below doesn't
+                 * propagate to the parent namespace, since we're leaving
+                 * the root directory shared */
+		if (mount("", "/sys", "none", MS_PRIVATE | MS_REC, NULL)) {
+			syslog (LOG_ERR, "\"mount --make-rprivate /sys\" failed: %s\n",
+					strerror(errno));
+			return -1;
+		}
+	}
+
+	/* Mount a version of /sys that describes the network namespace */
+	if (umount2("/sys", MNT_DETACH) < 0) {
+		struct statvfs fsstat;
+
+		/* If this fails, perhaps there wasn't a sysfs instance
+		 * mounted. Good. */
+		if (statvfs("/sys", &fsstat) == 0) {
+			/* We couldn't umount the sysfs, we'll attempt to
+			 * overlay it. A read-only instance can't be shadowed
+			 * with a read-write one. */
+			if (fsstat.f_flag & ST_RDONLY)
+				mountflags |= MS_RDONLY;
+		}
+	}
+
+	if (mount(name, "/sys", "sysfs", mountflags, NULL) < 0) {
+		syslog (LOG_ERR, "mount of /sys failed: %s", strerror(errno));
+		return -1;
+	}
+
+	if (mount("cgroup2", "/sys/fs/cgroup", "cgroup2", mountflags, NULL) < 0) {
+		syslog (LOG_ERR, "mount of /sys/fs/cgroup failed: %s", strerror(errno));
+		return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * create_netns_rundir: Create /var/run/netns mount if it doesn't exist yet.
+ */
+int create_netns_rundir(void)
+{
+	int rv = 0;
+
+	rv = mkdir(NETNS_RUN_DIR, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
+	if (rv == -1 && errno != EEXIST) {
+		syslog (LOG_ERR, "cannot create netns dir %s: %s",
+				NETNS_RUN_DIR, strerror(errno));
+		return -1;
+	}
+
+	rv = mount("", NETNS_RUN_DIR, "none", MS_SHARED | MS_REC, NULL);
+	if (rv == 0) {
+		return 0;
+	}
+
+	if (errno != EINVAL) {
+		syslog (LOG_ERR, "mount --make-shared %s: %s",
+				NETNS_RUN_DIR, strerror(errno));
+		return -1;
+	}
+
+	rv = mount(NETNS_RUN_DIR, NETNS_RUN_DIR, "none", MS_BIND, NULL);
+	if (rv == -1) {
+		syslog (LOG_ERR, "mount --bind %s: %s",
+				NETNS_RUN_DIR, strerror(errno));
+		return -1;
+	}
+
+	rv = mount("", NETNS_RUN_DIR, "none", MS_SHARED | MS_REC, NULL);
+	if (rv == -1) {
+		syslog (LOG_ERR, "mount --make-shared after bind %s: %s",
+				NETNS_RUN_DIR, strerror(errno));
+		return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * unshare_netns: Create new netns, including mounting the handle to ns_path.
+ */
+int unshare_netns(char *ns_path, int flags)
+{
+	int rv;
+	int nsfd;
+
+	nsfd = open(ns_path, O_RDONLY|O_CREAT|O_EXCL, 0);
+	if (nsfd < 0) {
+		syslog (LOG_ERR, "cannot create netns %s: %s",
+				ns_path, strerror(errno));
+		return -1;
+	}
+
+	close(nsfd);
+
+	rv = unshare(CLONE_NEWNET);
+	if (rv < 0) {
+		syslog (LOG_ERR, "Failed to create a new netns %s: %s",
+				ns_path, strerror(errno));
+		return -1;
+	}
+
+	rv = mount("/proc/self/ns/net", ns_path, "none", MS_BIND, NULL);
+	if (rv == -1) {
+		syslog (LOG_ERR, "mount /proc/self/ns/net -> %s failed: %s",
+				ns_path, strerror(errno));
+		return -1;
+	}
+
+	if ((flags & LODOWN) == 0)
+		nlinline_linksetupdown(1, 1); // bring lo up
+
+	return nsfd;
+}
+
+/**
+ * enter_netns: Ensure we are in the netns referred to by ns_path, either by
+ * creating it or entering it if it already exists.
+ */
+int enter_netns(char *ns_path, int flags)
+{
+	int nsfd;
+	nsfd = open(ns_path, O_RDONLY);
+	if (nsfd < 0) {
+		if (errno == ENOENT) {
+			unshare_netns(ns_path, flags);
+		} else {
+			syslog (LOG_ERR, "netns open failed %s", ns_path);
+			return -1;
+		}
+	} else {
+		if (setns(nsfd, CLONE_NEWNET) != 0) {
+			syslog (LOG_ERR, "cannot join netns %s: %s",
+					ns_path, strerror(errno));
+			close(nsfd);
+			return -1;
+		}
+		close(nsfd);
+	}
+
+	return 0;
+}
+
+/*
+ * PAM entry point for session creation
+ */
+int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	const char *user;
+	int rv;
+	char *target_netns = NULL;
+	char ns_path[PATH_MAX];
+	struct pam_net_args pam_args = {
+		.group = DEFAULT_GROUP,
+		.flags = 0};
+
+	init_log ("pam_groupnet");
+
+	parse_argv(&pam_args, argc, argv);
+
+	if ((rv=pam_get_user(pamh, &user, NULL) != PAM_SUCCESS)) {
+		syslog (LOG_ERR, "get user: %s", strerror(errno));
+		end_log();
+		return PAM_SUCCESS;
+	}
+
+	target_netns = get_groupnet_netns(user, pam_args.group);
+	if(target_netns == NULL) {
+		end_log();
+		return PAM_IGNORE;
+	}
+
+	if (create_netns_rundir() == -1)
+		goto close_log_and_abort;
+
+	snprintf(ns_path, sizeof(ns_path), "%s/%s", NETNS_RUN_DIR, target_netns);
+
+	rv = enter_netns(ns_path, pam_args.flags);
+	if(rv == -1)
+		goto close_log_and_abort;
+
+	if (unshare(CLONE_NEWNS) < 0) {
+		syslog (LOG_ERR, "unshare(mount) failed: %s", strerror(errno));
+		goto close_log_and_abort;
+	}
+
+	if(remount_sys(target_netns, pam_args.flags) == -1) {
+		syslog (LOG_ERR, "remounting /sys failed");
+		goto close_log_and_abort;
+	}
+
+	/* Setup bind mounts for config files in /etc */
+	if(bind_etc(target_netns, pam_args.flags) == -1) {
+		syslog (LOG_ERR, "mounting /etc/netns/%s config files failed",
+				target_netns);
+		goto close_log_and_abort;
+	}
+
+	end_log();
+	free(target_netns);
+	return PAM_SUCCESS;
+
+close_log_and_abort:
+	end_log();
+	free(target_netns);
+	return PAM_ABORT;
+}
+
+/*
+ * PAM entry point for session cleanup
+ */
+int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+{
+	return(PAM_IGNORE);
+}

--- a/pam_net_checkgroup.h
+++ b/pam_net_checkgroup.h
@@ -5,4 +5,9 @@
 /* 0=NO 1=YES -1=error */
 int checkgroup(const char *user, const char *group);
 
+/* get the name specified after a dash char '-' of "group" on a user.
+ * if the user is part of multiple groups starting with "group", returns data from first matching group. */
+/* NULL = not found/error. pointer must be freed. */
+char *get_groupnet_netns(const char *user, const char *group);
+
 #endif //PAM_NET_COMMON_H


### PR DESCRIPTION
Allows to specify which netns to join.
I know it's a bit of a strange use of groups, if you have suggestions on how to better specify a netns name do tell. This works for my usecase (VPN tunneling of multiple users, through a single shared stream/session) while keeping it simple.
The new module includes the mounting of the cgroup dir, continuing if `/etc/netns/<name>` does not exist, and more restricted mounts.